### PR TITLE
Add systemd sd_notify()

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,12 +4,18 @@ BIN:=libkvmchan.so
 LIBS=-lrt -pthread
 DEBUG:=true
 
+SYSTEMD ?= 1
+
 DAEMON_SRCS:=daemon/daemon.c daemon/libvirt.c daemon/util.c daemon/ivshmem.c daemon/vfio.c \
 	daemon/ipc.c daemon/connections.c daemon/localhandler.c
 DAEMON_DEPS:=$(DAEMON_SRCS:.c=.daemon.o)
 DAEMON_BIN:=kvmchand
 DAEMON_LIBS:=-lrt -pthread $(shell pkg-config --libs libvirt libvirt-qemu libxml-2.0)
 DAEMON_CFLAGS:=$(shell pkg-config --cflags libxml-2.0)
+ifeq ($(SYSTEMD),1)
+DAEMON_CFLAGS += -DHAVE_SYSTEMD
+DAEMON_LIBS += `pkg-config --libs libsystemd || pkg-config --libs libsystemd-daemon`
+endif
 
 TEST_SRCS:=test.c
 TEST_DEPS:=$(TEST_SRCS:.c=.o)

--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ BIN:=libkvmchan.so
 LIBS=-lrt -pthread
 DEBUG:=true
 
-SYSTEMD ?= 1
+SYSTEMD ?= 0
 
 DAEMON_SRCS:=daemon/daemon.c daemon/libvirt.c daemon/util.c daemon/ivshmem.c daemon/vfio.c \
 	daemon/ipc.c daemon/connections.c daemon/localhandler.c

--- a/daemon/vfio.c
+++ b/daemon/vfio.c
@@ -87,10 +87,6 @@
 #include "config.h"
 #include "libkvmchan-priv.h"
 
-#ifdef HAVE_SYSTEMD
-#include <systemd/sd-daemon.h>
-#endif
-
 #define REASONABLE_PATH_LEN 512
 #define IOMMU_GROUP_LENGTH  4
 
@@ -1223,22 +1219,6 @@ void run_vfio_loop(int mainsoc) {
     if (!vfio_init(&vfio, &ivshmem_devices))
         goto error;
     g_vfio_data = &vfio;
-
-#ifdef HAVE_SYSTEMD
-    log(LOGL_INFO, "guest_main: sd_notify");
-    /**
-     * sd_notify(int unset_environment, const char *state);
-     *
-     * If the unset_environment parameter is non-zero, sd_notify() will unset
-     * the $NOTIFY_SOCKET environment variable before returning (regardless of
-     * whether the function call itself succeeded or not). Further calls to
-     * sd_notify() will then fail, but the variable is no longer inherited by
-     * child processes.
-     */
-    if (getenv("NOTIFY_SOCKET")) {
-        sd_notify(1, "READY=1");
-    }
-#endif /* HAVE_SYSTEMD */
 
     // Epoll loop to check for disconnected devices
     struct epoll_event events[5];


### PR DESCRIPTION
A systemd unit file that has the 'Type' set to 'notify' enables the ability for systemd to notify any unit that 'Requires' it when a call is made to sd_nofify().  The unit file that requires to be notified will not start until systemd recieves a 'READY=1' message which allows services that rely on another service to be fully initialized to wait preventing race conditions.
    
The kvmchand service unit file service 'Type' was changed from 'simple' to 'notify' and dropins were added for qubes-db.service and qubes-qrexec.service to `Require` the kvmchand.service unit to force them to wait until kvmchan initialization is complete since the services were starting too early which caused fatal communication errors that could not recover.
